### PR TITLE
Fix path to typescript file in the example

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -90,8 +90,8 @@ const html = {
 const ts = {
 	serverUri: 'ws://localhost:3001/typescript',
 	languageId: 'typescript',
-	rootUri: `file:///${normalize(path.join(__dirname,'example-project'))}`,
-	documentUri:  `file:///${normalize(path.join(__dirname,'example-project/source.ts'))}`,
+	rootUri: `file://${normalize(path.join(__dirname,'example-project'))}`,
+	documentUri:  `file://${normalize(path.join(__dirname,'example-project/source.ts'))}`,
 	documentText: () => tsEditor.getValue(),
 };
 


### PR DESCRIPTION
Thanks for this example repo, I found it useful.
Here's a fix in the URL of typescript file in the example as the example was returning LSP errors about invalid URL.